### PR TITLE
Have instance be an property instead of a static member

### DIFF
--- a/Sources/TextImageComposite/TextImageComposite/TICConfig.swift
+++ b/Sources/TextImageComposite/TextImageComposite/TICConfig.swift
@@ -16,7 +16,8 @@ public class TextImageComposite
 
 public class TICConfig
 {
-    static public let instance = TICConfig()
+    
+    static var _instance: TICConfig? = nil
     
     public var text: String             = ""
     public var reference: String        = ""
@@ -30,6 +31,13 @@ public class TICConfig
     public var selectedImage : UIImage?
     public var selectedURL : URL?
     public var watermarkImage: TICWatermark?
+    
+    public static var instance: TICConfig {
+        if _instance == nil {
+            _instance = TICConfig()
+        }
+        return _instance!
+    }
     
     public var bundle: Bundle {
         let bundle = Bundle(identifier: "org.sil.TextImageComposite")


### PR DESCRIPTION
This allows the Framework to be optional (without static
initialization of data)